### PR TITLE
Fix vec i8 issue

### DIFF
--- a/rust_prettifier_for_lldb.py
+++ b/rust_prettifier_for_lldb.py
@@ -67,7 +67,11 @@ def initialize_category(debugger, internal_dict):
     attach_synthetic_to_type(MsvcTupleSynthProvider, r'^tuple\$?<.+>$', True)
 
     attach_synthetic_to_type(CharSynthProvider, 'char32_t')
+
+    # there is no 1 byte char type in rust, so these have to be u8/i8
     attach_synthetic_to_type(U8SynthProvider, 'unsigned char')
+    attach_synthetic_to_type(I8SynthProvider, 'char')
+
     attach_synthetic_to_type(StrSliceSynthProvider, '&str')
     attach_synthetic_to_type(StrSliceSynthProvider, 'str*')
     # *-windows-msvc uses this name since 1.5?
@@ -376,8 +380,6 @@ class RustSynthProvider(object):
 
 
 class CharSynthProvider(RustSynthProvider):
-    summary = ''
-
     def update(self):
         value = self.valobj.GetValueAsUnsigned()
         c = chr(value)
@@ -388,10 +390,14 @@ class CharSynthProvider(RustSynthProvider):
 
 
 class U8SynthProvider(RustSynthProvider):
-    summary = ''
-
     def update(self):
         value = self.valobj.GetValueAsUnsigned()
+        self.summary = f"{int(value)}"
+
+
+class I8SynthProvider(RustSynthProvider):
+    def update(self):
+        value = self.valobj.GetValueAsSigned()
         self.summary = f"{int(value)}"
 
 

--- a/rust_test_crate/main.rs
+++ b/rust_test_crate/main.rs
@@ -10,6 +10,18 @@ use std::{
 
 use core::iter::FromIterator;
 
+fn basic_datatypes() {
+    let x: char = 'A';
+    let y: i8 = 65;
+    let z: i8 = -128;
+    let w: u8 = 65;
+
+    let xx: i16 = 1000;
+    let xy: u16 = 1000;
+
+    println!("</basic_datatypes>")
+}
+
 #[derive(Default)]
 struct StructWithManyMembers {
     x: i32,
@@ -104,6 +116,11 @@ fn collections() {
     let array_2 = [[1, 2, 3], [4, 5, 6]];
     let v = vec![1, 2, 3];
     let vd = VecDeque::from_iter([1, 2, 3]);
+
+    let vec_i8 = vec![3i8, -1i8, 'A' as i8];
+
+    let vec_char = vec!['A', 'B', 'C'];
+
     println!("</collections>");
 }
 
@@ -136,6 +153,7 @@ fn demo() {
 }
 
 fn main() {
+    basic_datatypes();
     enums();
     hashmap();
     collections();

--- a/tests/test_basic_types.py
+++ b/tests/test_basic_types.py
@@ -10,6 +10,24 @@ def test_u8(tmpdir):
     })
 
 
+# regression test for #2
+def test_i8(tmpdir):
+    src = """
+        let x: i8 = -128;
+    """
+
+    # TODO: we would prefer to get rid of the
+    # '\x80' here, but I have no idea how.
+    # Disabling the cplusplus Category and other potentially conflicting
+    # Sources did unfortunately not help.
+    expect_command_output(tmpdir, src, [
+        ("v x", "(char) x = '\\x80' -128\n")
+    ])
+    expect_summaries(tmpdir, src, {
+        "x": "-128",
+    })
+
+
 def test_char(tmpdir):
     src = """
         let x: char = 'A';
@@ -18,6 +36,9 @@ def test_char(tmpdir):
     expect_summaries(tmpdir, src, {
         "x": "'A'",
         "y": "U+0x0000000A"
+    })
+    expect_command_output(tmpdir, src, {
+        ("v x", "(char32_t) x = U+0x00000041 'A'\n")
     })
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -19,6 +19,20 @@ def test_basic_vec_child_access(tmpdir):
     ])
 
 
+# regression test for #2
+def test_vec_i8(tmpdir):
+    src = """
+        let x = vec![1i8, -1i8, 'A' as i8];
+    """
+    expect_summaries(tmpdir, src, {
+        "x": "(3) vec![1, -1, 65]"
+    })
+    # TODO: see test_basic_types.test_i8 for explanation
+    expect_command_output(tmpdir, src, [
+        ("v x[1]", "(char) x[1] = '\\xff' -1\n")
+    ])
+
+
 def test_basic_vec_deque(tmpdir):
     src = """
         use std::collections::VecDeque;


### PR DESCRIPTION
Addresses #2 and provides a partial fix.

We still have an issue where the details will show  `(char) [0] = '\xFF' -1` instead of what we would actually want:  `(char) [0] = -1`, or even `(i8) [0] = '\xFF' -1`.

But this at least fixes the `vec` summary and makes it *usable* for people, despite still being a bit ugly. 