### PR TITLE
Add crossbream atomic cell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /.venv
 __pycache__
 
-
+/target
 /rust_test_crate/target

--- a/rust_prettifier_for_lldb.py
+++ b/rust_prettifier_for_lldb.py
@@ -147,6 +147,9 @@ def initialize_category(debugger, internal_dict):
     attach_synthetic_to_type(CowSynthProvider,
                              r'^alloc::borrow::Cow<.+>$', True)
 
+    attach_synthetic_to_type(CrossbeamAtomicCellSynthProvider,
+                             r'^crossbeam_utils::atomic::atomic_cell::AtomicCell<.+>$', True)
+
     debugger.HandleCommand(
         "type summary add"
         + f" --python-function {__name__}.enum_summary_provider"
@@ -1192,6 +1195,11 @@ class StdHashSetSynthProvider(StdHashMapSynthProvider):
         bucket_idx = self.valid_indices[index]
         item = self.buckets.GetChildAtIndex(bucket_idx).GetChildAtIndex(0)
         return item.CreateChildAtOffset('[%d]' % index, 0, item.GetType())
+
+class CrossbeamAtomicCellSynthProvider(DerefSynthProvider):
+    def update(self):
+        self.deref = gcm(self.valobj, 'value', 'value', 'value', 'value')
+        self.deref.SetPreferSyntheticValue(True)
 
 
 def __lldb_init_module(debugger_obj, internal_dict):  # pyright: ignore

--- a/tests/test_crossbeam.py
+++ b/tests/test_crossbeam.py
@@ -1,0 +1,11 @@
+from test_harness import expect_summaries
+
+def test_crossbeam_atomic_cell(tmpdir):
+    src = """
+        use crossbeam::atomic::AtomicCell;
+
+        let atomic_cell = AtomicCell::new(42);
+    """
+    expect_summaries(tmpdir, src, {
+        "atomic_cell": "42",
+    })

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -21,6 +21,8 @@ def run_rust_test(
     rust_src: str,
     test_code: Callable[[lldb.SBDebugger, lldb.SBFrame], None]
 ):
+    project_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    target_dir = os.path.join(project_dir, "target")
     src_path = os.path.join(str(temp_dir), "src/main.rs")
     os.makedirs(os.path.dirname(src_path), exist_ok=True)
     cargo_toml_path = os.path.join(str(temp_dir), "Cargo.toml")
@@ -41,12 +43,12 @@ def run_rust_test(
 
     rust_src = "fn main() {\n" + rust_src + "\n}\n"
 
-    binary_path = os.path.join(str(temp_dir), "target/debug/main")
+    binary_path = os.path.join(target_dir, "debug/main")
     with open(src_path, "w") as f:
         f.write(rust_src)
 
     result = subprocess.run(
-        ["cargo", "build"],
+        ["cargo", "build", "--target-dir", target_dir],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         cwd=str(temp_dir)


### PR DESCRIPTION
This adds support for crossbeam AtomicCells, which was useful for me. Adding the test required changing the test harnessing to use cargo instead of rustc to pull in dependencies. 

Test execution time is adversely affected. Some results from `time pytest`: 

**On main**: 
`8.84s user 4.91s system 111% cpu 12.358 total`
**With cargo**: 
`53.33s user 17.69s system 155% cpu 45.581 total`
**With cargo, and shared target directory (3rd commit)**: 
`10.21s user 6.03s system 105% cpu 15.395 total`

Absolutely feel free to reject if you don't want to add the complication for the sake of supporting crossbeam types. I'm happy to just roll with my version, and that you did 99.9% of the work and showed me how to do it. Thanks!